### PR TITLE
Fixed Access denied for user 'vagrant'@'localhost' 

### DIFF
--- a/playbooks/roles/mysql/tasks/mysql.yml
+++ b/playbooks/roles/mysql/tasks/mysql.yml
@@ -29,7 +29,7 @@
 
 - name: MySQL | Config for easy access as root user
   template: src=mysql_root.my.cnf.j2 dest=/root/.my.cnf
-  when: "'{{ user }}' == 'root'"
+  sudo: true
 
 - name: MySQL | Config for easy access as root user
   template: src=mysql_root.my.cnf.j2 dest={{ home_dir }}/.my.cnf

--- a/playbooks/roles/mysql/tasks/mysql.yml
+++ b/playbooks/roles/mysql/tasks/mysql.yml
@@ -25,6 +25,7 @@
 # MySQL database setup, this does the equivalent of mysql_secure_installation.
 - name: MySQL | Set the root password.
   mysql_user: name=root password={{ mysql_root_password }} host=localhost
+  sudo: true
 
 - name: MySQL | Config for easy access as root user
   template: src=mysql_root.my.cnf.j2 dest=/root/.my.cnf


### PR DESCRIPTION
Hi, 

I use the vagrant up and show this message for me:

`{"changed": false, "failed": true, "invocation": {"module_args": {"append_privs": false, "check_implicit_admin": false, "config_file": "~/.my.cnf", "encrypted": false, "host": "localhost", "login_host": "localhost", "login_password": null, "login_port": 3306, "login_unix_socket": null, "login_user": null, "name": "root", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "priv": null, "ssl_ca": null, "ssl_cert": null, "ssl_key": null, "state": "present", "update_password": "always", "user": "root"}, "module_name": "mysql_user"}, "msg": "unable to connect to database, check login_user and login_password are correct or /home/vagrant/.my.cnf has the credentials. Exception message: (1045, \"Access denied for user 'vagrant'@'localhost' (using password: NO)\")"}`

I added `sudo: true` in the Set the root password.

thank you very much!!
