### PR TITLE
Fixed install grunt bower and gulp.

### DIFF
--- a/playbooks/roles/front/tasks/nodejs.yml
+++ b/playbooks/roles/front/tasks/nodejs.yml
@@ -18,9 +18,7 @@
   sudo: true
 
 - name: NodeJS | Install Grunt, Bower and Gulp
-  npm: name={{ item }}
-       state=latest
-       global=yes
+  command: npm install -g {{ item }}
   sudo: true
   with_items:
     - grunt


### PR DESCRIPTION
Hi, the ansible doesn't intall grunt, bower and gulp. Show this message in the check install:

`2016-04-16 00:54:53,201 p=16244 u=edmar |  TASK [Test | Grunt is installed] ***********************************************
2016-04-16 00:54:53,201 p=16244 u=edmar |  task path: /home/edmar/projetos/nyx/bondinho-admin/playbooks/tests/front.yml:8
2016-04-16 00:54:53,356 p=16244 u=edmar |  fatal: [bondinho]: FAILED! => {"changed": true, "cmd": "grunt --version", "delta": "0:00:00.002026", "end": "2016-04-16 03:54:53.409357", "failed": true, "invocation": {"module_args": {"_raw_params": "grunt --version", "_uses_shell": true, "chdir": null, "creates": null, "executable": null, "removes": null, "warn": true}, "module_name": "command"}, "rc": 127, "start": "2016-04-16 03:54:53.407331", "stderr": "/bin/sh: 1: grunt: not found", "stdout": "", "stdout_lines": [], "warnings": []}
2016-04-16 00:54:53,359 p=16244 u=edmar |   to retry, use: --limit @/home/edmar/projetos/nyx/bondinho-admin/playbooks/setup.retry`

I remove the npm and added command.

thanks
