### PR TITLE
Added php7 xml package to the install.

### DIFF
--- a/playbooks/roles/php/tasks/php.yml
+++ b/playbooks/roles/php/tasks/php.yml
@@ -23,6 +23,7 @@
     - php7.0-opcache
     - php7.0-intl
     - php7.0-bz2
+    - php7.0-xml
   sudo: true
 
 - name: PHP | FPM php.ini


### PR DESCRIPTION
Hi,

For you install Drupal 8 is necessary install the php7 xml package.

thanks
